### PR TITLE
Implement basic window runner and webpage stubs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["crates/ui_shell", "crates/browser_core", "crates/desktop_launcher"]
+members = [
+    "crates/gpui",
+    "crates/ui_shell",
+    "crates/browser_core",
+    "crates/desktop_launcher",
+]
 resolver = "2"

--- a/crates/browser_core/src/lib.rs
+++ b/crates/browser_core/src/lib.rs
@@ -1,5 +1,19 @@
-pub struct WebPage;
+use std::sync::Arc;
+
+use servo_webview::WebView;
+use wgpu::{Device, Queue, TextureView};
+
+pub struct WebPage {
+    inner: WebView,
+}
 
 impl WebPage {
-    pub fn new() {}
+    pub fn new(url: &str, device: Arc<Device>, queue: Arc<Queue>) -> Self {
+        let inner = WebView::new(url, device, queue);
+        Self { inner }
+    }
+
+    pub fn next_frame(&mut self) -> Option<TextureView> {
+        self.inner.next_frame()
+    }
 }

--- a/crates/desktop_launcher/src/main.rs
+++ b/crates/desktop_launcher/src/main.rs
@@ -1,3 +1,31 @@
+use browser_core::WebPage;
+
 fn main() {
-    println!("Glider skeleton OK");
+    let mut args = std::env::args().skip(1);
+    let mut headless = false;
+    let mut url = "https://www.google.com".to_string();
+
+    if let Some(arg) = args.next() {
+        if arg == "--headless" {
+            headless = true;
+            if let Some(u) = args.next() {
+                url = u;
+            }
+        } else {
+            url = arg;
+        }
+    }
+
+    if headless {
+        return;
+    }
+
+    ui_shell::run_window(|cx| {
+        let device = cx.gpu().device();
+        let queue = cx.gpu().queue();
+        let mut page = WebPage::new(&url, device, queue);
+        if let Some(_tex) = page.next_frame() {
+            cx.needs_repaint();
+        }
+    });
 }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "servo-webview"
+name = "gpui"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/gpui/src/lib.rs
+++ b/crates/gpui/src/lib.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+use wgpu::{Device, Queue};
+
+pub struct Application;
+
+impl Application {
+    pub fn new() -> Self {
+        Application
+    }
+
+    pub fn run<F: FnOnce(&mut AppContext)>(self, f: F) {
+        let mut cx = AppContext::new();
+        f(&mut cx);
+    }
+}
+
+pub struct AppContext;
+
+impl AppContext {
+    fn new() -> Self {
+        AppContext
+    }
+
+    pub fn open_window<T: Render + 'static>(&mut self, _options: WindowOptions, mut content: T) {
+        let mut rc = RenderContext;
+        content.render(&mut rc);
+    }
+
+    pub fn gpu(&self) -> Gpu {
+        Gpu
+    }
+
+    pub fn needs_repaint(&mut self) {}
+}
+
+pub struct Gpu;
+
+impl Gpu {
+    pub fn device(&self) -> Arc<Device> {
+        unimplemented!()
+    }
+
+    pub fn queue(&self) -> Arc<Queue> {
+        unimplemented!()
+    }
+}
+
+pub trait Render {
+    fn render(&mut self, cx: &mut RenderContext);
+}
+
+pub struct RenderContext;
+
+#[derive(Default)]
+pub struct WindowOptions {
+    pub title: String,
+    pub size: (u32, u32),
+}
+
+impl WindowOptions {
+    pub fn new(title: &str, width: u32, height: u32) -> Self {
+        Self {
+            title: title.into(),
+            size: (width, height),
+        }
+    }
+}

--- a/crates/ui_shell/Cargo.toml
+++ b/crates/ui_shell/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-gpui = { git = "https://github.com/zed-industries/zed", rev = "HEAD" }
+gpui = { path = "../gpui" }

--- a/crates/ui_shell/src/lib.rs
+++ b/crates/ui_shell/src/lib.rs
@@ -1,5 +1,19 @@
+use gpui::{AppContext, Application, Render, RenderContext, WindowOptions};
+
 pub struct Root;
 
-impl gpui::Render for Root {
-    fn render(&mut self, _cx: &mut gpui::RenderContext) {}
+impl Render for Root {
+    fn render(&mut self, _cx: &mut RenderContext) {}
+}
+
+pub fn run_window<F>(init: F)
+where
+    F: FnOnce(&mut AppContext),
+{
+    let app = Application::new();
+    app.run(|cx| {
+        init(cx);
+        let opts = WindowOptions::new("Glider", 1280, 800);
+        cx.open_window(opts, Root);
+    });
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+use std::time::Duration;
+use std::thread::sleep;
+
+#[test]
+fn smoke() {
+    let mut child = Command::new("cargo")
+        .args(["run", "-p", "desktop_launcher", "--", "--headless", "about:blank"])
+        .spawn()
+        .expect("failed to run desktop_launcher");
+
+    sleep(Duration::from_secs(3));
+    let status = child.wait().expect("failed to wait");
+    assert!(status.success());
+}

--- a/third_party/servo/components/servo-webview/src/lib.rs
+++ b/third_party/servo/components/servo-webview/src/lib.rs
@@ -1,1 +1,14 @@
-pub fn stub() {}
+use std::sync::Arc;
+use wgpu::{Device, Queue, TextureView};
+
+pub struct WebView;
+
+impl WebView {
+    pub fn new(_url: &str, _device: Arc<Device>, _queue: Arc<Queue>) -> Self {
+        WebView
+    }
+
+    pub fn next_frame(&mut self) -> Option<TextureView> {
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- add local `gpui` crate with minimal API stubs
- fix servo-webview crate name and add stub `WebView`
- implement `WebPage` wrapper around servo-webview
- implement `run_window` helper in `ui_shell`
- update desktop launcher to open a webpage
- add a simple integration test

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683d2a11b974832497fc5732769ca4b1